### PR TITLE
Fix/table name validation detection

### DIFF
--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -372,7 +372,7 @@ class PostgresTarget(SQLInterface):
     def write_table_batch(self, cur, table_batch, metadata):
         remote_schema = table_batch['remote_schema']
 
-        target_table_name = self.get_temp_table_name(remote_schema['name'])
+        target_table_name = self.get_temp_table_name()
 
         ## Create temp table to upload new data to
         self.create_table(cur,
@@ -510,8 +510,8 @@ class PostgresTarget(SQLInterface):
                                remote_table_json_schema,
                                schema)
 
-    def get_temp_table_name(self, stream_name):
-        return stream_name + SEPARATOR + str(uuid.uuid4()).replace('-', '')
+    def get_temp_table_name(self):
+        return 'tmp_' + str(uuid.uuid4()).replace('-', '_')
 
     def get_table_metadata(self, cur, table_name):
         cur.execute(

--- a/target_postgres/postgres.py
+++ b/target_postgres/postgres.py
@@ -490,6 +490,8 @@ class PostgresTarget(SQLInterface):
 
 
     def create_table(self, cur, table_name, schema, table_version):
+        self._validate_identifier(table_name)
+
         create_table_sql = sql.SQL('CREATE TABLE {}.{}').format(
                 sql.Identifier(self.postgres_schema),
                 sql.Identifier(table_name))


### PR DESCRIPTION
# Motivation

https://github.com/datamill-co/target-postgres/issues/18#issuecomment-443284112

Sooooo, fun thing:

```
target_postgres_test=# create table cats__1__adoption__immunizations__5d3f791dacf047c0ae3cebefe2af74b2 ();
NOTICE:  identifier "cats__1__adoption__immunizations__5d3f791dacf047c0ae3cebefe2af74b2" will be truncated to "cats__1__adoption__immunizations__5d3f791dacf047c0ae3cebefe2af7"
CREATE TABLE

```

That's the name of one of the temp tables we generate. That just _happens_ to work right now. This pr removes the variability in temp table name generation length and instead just uses a `uuid` to uniquely identify tmps.

## Suggested Musical Pairing

https://soundcloud.com/unknownmortalorchestra/hunnybee